### PR TITLE
[parse-server] add nodejs version 6 from node:boron

### DIFF
--- a/parse-server-dashboard/config.json
+++ b/parse-server-dashboard/config.json
@@ -1,7 +1,7 @@
 {
   "apps": [
     {
-      "serverURL": "http://DASHBOARD_HOSTNAME:1337/parse",
+      "serverURL": "http://localhost:1337/parse",
       "appId": "APP_ID",
       "masterKey": "MASTER_KEY",
       "appName": "APP_NAME"

--- a/parse-server/Dockerfile
+++ b/parse-server/Dockerfile
@@ -1,12 +1,6 @@
-FROM debian:jessie
+FROM node:boron
 
 RUN apt-get update && apt-get dist-upgrade -y
-
-RUN apt-get install -y curl
-
-RUN curl -sL https://deb.nodesource.com/setup_5.x | bash -
-
-RUN apt-get install -y nodejs
 
 RUN npm install -g parse-server
 

--- a/parse-server/config.json
+++ b/parse-server/config.json
@@ -1,6 +1,6 @@
 {
-  "appId": "parse",
-  "masterKey": "parsekey",
+  "appId": "APP_ID",
+  "masterKey": "MASTER_KEY",
   "databaseURI": "mongodb://mongodb:27017/dev",
   "push": {
     "android": {


### PR DESCRIPTION
Parse server need nodejs 6.

The fix use node:boron who is on this version